### PR TITLE
chore: add `dist` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist-ssr
+dist
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
Without this `dist` added to the gitignore, Katana is still reporting changes in the submodule related to the `explorer/ui`.

Adding it ensures the new `build.rs` in Katana is not generating a `git diff`.