### PR TITLE
chore: update event converter types

### DIFF
--- a/src/modules/EventDetails/page.tsx
+++ b/src/modules/EventDetails/page.tsx
@@ -19,7 +19,7 @@ import PageHeader from "@/shared/components/PageHeader";
 import { SectionBox } from "@/shared/components/section/SectionBox";
 import { SectionBoxEntry } from "@/shared/components/section";
 
-const DisplayFormat = ["decimal", "hex", "string"] as const;
+const DisplayFormat = ["dec", "hex", "string"] as const;
 
 export default function EventDetails() {
   const { eventId } = useParams<{


### PR DESCRIPTION
i fix the error where decimal conversions didn't work
<img width="915" alt="Screenshot 2025-04-02 at 1 21 20 PM" src="https://github.com/user-attachments/assets/b750f33a-d59c-4e1c-9c7e-dd1857f9a7ab" />
