### PR TITLE
chore: add presets as part of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@cartridge/connector": "^0.6.0",
     "@cartridge/controller": "^0.6.0",
+    "@cartridge/presets": "github:cartridge-gg/presets#2373780", 
     "@cartridge/ui-next": "0.5.0-alpha.1",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-slot": "^1.1.2",


### PR DESCRIPTION
I used the exact same version which is used in our utils package which is breaking. 

Ref - https://github.com/cartridge-gg/controller/blob/main/package.json#L34

this is in context of this error which comes when you clone this repo  - 

```
pnpm run dev

> @cartridge/explorer@0.0.0 dev /Users/ayushtomar/Desktop/explorer
> vite

9:58:13 pm [vite] (client) Re-optimizing dependencies because lockfile has changed

  VITE v6.2.5  ready in 397 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
✘ [ERROR] Could not resolve "@cartridge/presets"

    node_modules/.pnpm/@cartridge+utils@0.5.9_react-dom@18.3.1_react@18.3.1__typescript@5.6.3_zod@3.24.2/node_modules/@cartridge/utils/dist/hooks/balance.js:6:30:
      6 │ import { erc20Metadata } from "@cartridge/presets";
        ╵                               ~~~~~~~~~~~~~~~~~~~~

  You can mark the path "@cartridge/presets" as external to exclude it from the bundle, which will
  remove this error and leave the unresolved path in the bundle.

/Users/ayushtomar/Desktop/explorer/node_modules/.pnpm/esbuild@0.25.2/node_modules/esbuild/lib/main.js:1477
  let error = new Error(text);
              ^

Error: Build failed with 1 error:
node_modules/.pnpm/@cartridge+utils@0.5.9_react-dom@18.3.1_react@18.3.1__typescript@5.6.3_zod@3.24.2/node_modules/@cartridge/utils/dist/hooks/balance.js:6:30: ERROR: Could not resolve "@cartridge/presets"
    at failureErrorWithLog (/Users/ayushtomar/Desktop/explorer/node_modules/.pnpm/esbuild@0.25.2/node_modules/esbuild/lib/main.js:1477:15)
    at /Users/ayushtomar/Desktop/explorer/node_modules/.pnpm/esbuild@0.25.2/node_modules/esbuild/lib/main.js:946:25
    at /Users/ayushtomar/Desktop/explorer/node_modules/.pnpm/esbuild@0.25.2/node_modules/esbuild/lib/main.js:1355:9
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
}

Node.js v20.9.0
 ELIFECYCLE  Command failed with exit code 1.
 ```