### PR TITLE
chore(gitignore): add dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist-ssr
+dist
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
seems the default output is dist (at least that's what happens in the dojo repo) so figured this would be good to have