### PR TITLE
feat: dynamic assets link

### DIFF
--- a/dynamic-link.ts
+++ b/dynamic-link.ts
@@ -1,81 +1,108 @@
-import { PluginOption } from "vite";
+import { Plugin } from "vite";
 
-const DYNAMIC_ASSETS_LOADING_TEMPLATE = `
+function createFaviconAssetTemplate(path: string): string {
+  return `
+	// Favicon
+	const iconLink = document.createElement("link");
+	iconLink.rel = "icon";
+	iconLink.type = "image/svg+xml";
+	iconLink.href = basePath + "${path}";
+	document.head.appendChild(iconLink);
+`;
+}
+
+function createCssAssetTemplate(path: string): string {
+  return `
+	// CSS
+	const cssLink = document.createElement("link");
+	cssLink.rel = "stylesheet";
+	cssLink.href = basePath + "${path}";
+	cssLink.setAttribute("crossorigin", "");
+	document.head.appendChild(cssLink);
+`;
+}
+
+function createJsAssetTemplate(path: string): string {
+  return `
+	// JS
+	const script = document.createElement("script");
+	script.type = "module";
+	script.src = basePath + "${path}";
+	script.setAttribute("crossorigin", "");
+	document.head.appendChild(script);
+`;
+}
+
+function dynamicAssetsLoadingTemplate(
+  favicon?: string,
+  css?: string,
+  js?: string
+) {
+  if (!favicon && !css && !js) {
+    return;
+  }
+
+  return `
 <script>
-		document.addEventListener("DOMContentLoaded", function () {
-				const currentPath = window.location.pathname;
-				const basePath = currentPath.substring(
-						0,
-						currentPath.lastIndexOf("/") + 1
-				);
+	document.addEventListener("DOMContentLoaded", function () {
+		const currentPath = window.location.pathname;
+		const basePath = currentPath.substring(
+			0,
+			currentPath.lastIndexOf("/") + 1
+		);
 
-				// Favicon
-				const iconLink = document.createElement("link");
-				iconLink.rel = "icon";
-				iconLink.type = "image/svg+xml";
-				iconLink.href = basePath + "/cartridge.svg";
-				document.head.appendChild(iconLink);
-
-				// CSS
-				const cssLink = document.createElement("link");
-				cssLink.rel = "stylesheet";
-				cssLink.href = basePath + "<PATH_TO_CSS_ASSET>";
-				cssLink.setAttribute("crossorigin", "");
-				document.head.appendChild(cssLink);
-
-				// JS
-				const script = document.createElement("script");
-				script.type = "module";
-				script.src = basePath + "<PATH_TO_JS_ASSET>";
-				script.setAttribute("crossorigin", "");
-				document.head.appendChild(script);
-		});
+		${favicon || ""}
+		${css || ""}
+		${js || ""}
+	});
 </script>
 `;
+}
 
-export default function dynamicLinksPlugin(): PluginOption[] {
-  return [
-    {
-      name: "vite-plugin-dynamic-links",
-      transformIndexHtml(html: string): string {
-        // Find the CSS path
-        const cssMatch = html.match(
-          /<link rel="stylesheet" crossorigin href="([^"]+)">/
-        );
-        const jsMatch = html.match(
-          /<script type="module" crossorigin src="([^"]+)"><\/script>/
-        );
+export default function dynamicLinksPlugin(): Plugin {
+  return {
+    name: "vite-plugin-dynamic-links",
+    transformIndexHtml(html: string): string {
+      const faviconRegex =
+        /<link rel="icon" type="image\/svg+xml" href="([^"]+)" \/>/;
+      const cssRegex = /<link rel="stylesheet" crossorigin href="([^"]+)">/;
+      const jsRegex =
+        /<script type="module" crossorigin src="([^"]+)"><\/script>/;
 
-        if (cssMatch && jsMatch) {
-          // Extract the asset paths
-          const cssPath = cssMatch[1].replace(/^\//, ""); // Remove leading slash if present
-          const jsPath = jsMatch[1].replace(/^\//, "");
+      const faviconMatch = html.match(faviconRegex);
+      const cssMatch = html.match(cssRegex);
+      const jsMatch = html.match(jsRegex);
 
-          // Create the dynamic loading template with actual asset paths
-          const scriptTemplate = DYNAMIC_ASSETS_LOADING_TEMPLATE.replace(
-            "<PATH_TO_CSS_ASSET>",
-            cssPath
-          ).replace("<PATH_TO_JS_ASSET>", jsPath);
+      let faviconTemplate;
+      if (faviconMatch) {
+        const faviconPath = faviconMatch[1].replace(/^\//, "");
+        faviconTemplate = createFaviconAssetTemplate(faviconPath);
+      }
 
-          // Remove the static link and script tags (they're now loaded dynamically)
-          html = html.replace(/\/cartridge.svg/g, "");
-          html = html.replace(
-            /<script type="module" crossorigin src="[^"]+"><\/script>/g,
-            ""
-          );
-          html = html.replace(
-            /<link rel="stylesheet" crossorigin href="[^"]+">/g,
-            ""
-          );
+      let cssTemplate;
+      if (cssMatch) {
+        const cssPath = cssMatch[1].replace(/^\//, "");
+        cssTemplate = createCssAssetTemplate(cssPath);
+      }
 
-          // Insert the dynamic loading template after the <head> tag
-          html = html.replace(/<head>/, `<head>${scriptTemplate}`);
+      let jsTemplate;
+      if (jsMatch) {
+        const jsPath = jsMatch[1].replace(/^\//, "");
+        jsTemplate = createJsAssetTemplate(jsPath);
+      }
 
-          return html;
-        }
+      const fullTemplate = dynamicAssetsLoadingTemplate(
+        faviconTemplate,
+        cssTemplate,
+        jsTemplate
+      );
 
-        return html;
-      },
+      if (fullTemplate) {
+        // Insert the dynamic loading template after the <head> tag
+        html = html.replace(/<head>/, `<head>${fullTemplate}`);
+      }
+
+      return html;
     },
-  ];
+  };
 }

--- a/dynamic-link.ts
+++ b/dynamic-link.ts
@@ -52,26 +52,26 @@ export default function dynamicLinksPlugin(): PluginOption[] {
           const jsPath = jsMatch[1].replace(/^\//, "");
 
           // Create the dynamic loading template with actual asset paths
-          let updatedHtml = DYNAMIC_ASSETS_LOADING_TEMPLATE.replace(
+          const scriptTemplate = DYNAMIC_ASSETS_LOADING_TEMPLATE.replace(
             "<PATH_TO_CSS_ASSET>",
             cssPath
           ).replace("<PATH_TO_JS_ASSET>", jsPath);
 
           // Remove the static link and script tags (they're now loaded dynamically)
-          updatedHtml = updatedHtml.replace(/\/cartridge.svg/g, "");
-          updatedHtml = html.replace(
+          html = html.replace(/\/cartridge.svg/g, "");
+          html = html.replace(
             /<script type="module" crossorigin src="[^"]+"><\/script>/g,
             ""
           );
-          updatedHtml = updatedHtml.replace(
+          html = html.replace(
             /<link rel="stylesheet" crossorigin href="[^"]+">/g,
             ""
           );
 
           // Insert the dynamic loading template after the <head> tag
-          updatedHtml = updatedHtml.replace(/<head>/, `<head>${updatedHtml}`);
+          html = html.replace(/<head>/, `<head>${scriptTemplate}`);
 
-          return updatedHtml;
+          return html;
         }
 
         return html;

--- a/dynamic-link.ts
+++ b/dynamic-link.ts
@@ -1,0 +1,81 @@
+import { PluginOption } from "vite";
+
+const DYNAMIC_ASSETS_LOADING_TEMPLATE = `
+<script>
+		document.addEventListener("DOMContentLoaded", function () {
+				const currentPath = window.location.pathname;
+				const basePath = currentPath.substring(
+						0,
+						currentPath.lastIndexOf("/") + 1
+				);
+
+				// Favicon
+				const iconLink = document.createElement("link");
+				iconLink.rel = "icon";
+				iconLink.type = "image/svg+xml";
+				iconLink.href = basePath + "/cartridge.svg";
+				document.head.appendChild(iconLink);
+
+				// CSS
+				const cssLink = document.createElement("link");
+				cssLink.rel = "stylesheet";
+				cssLink.href = basePath + "<PATH_TO_CSS_ASSET>";
+				cssLink.setAttribute("crossorigin", "");
+				document.head.appendChild(cssLink);
+
+				// JS
+				const script = document.createElement("script");
+				script.type = "module";
+				script.src = basePath + "<PATH_TO_JS_ASSET>";
+				script.setAttribute("crossorigin", "");
+				document.head.appendChild(script);
+		});
+</script>
+`;
+
+export default function dynamicLinksPlugin(): PluginOption[] {
+  return [
+    {
+      name: "vite-plugin-dynamic-links",
+      transformIndexHtml(html: string): string {
+        // Find the CSS path
+        const cssMatch = html.match(
+          /<link rel="stylesheet" crossorigin href="([^"]+)">/
+        );
+        const jsMatch = html.match(
+          /<script type="module" crossorigin src="([^"]+)"><\/script>/
+        );
+
+        if (cssMatch && jsMatch) {
+          // Extract the asset paths
+          const cssPath = cssMatch[1].replace(/^\//, ""); // Remove leading slash if present
+          const jsPath = jsMatch[1].replace(/^\//, "");
+
+          // Create the dynamic loading template with actual asset paths
+          let updatedHtml = DYNAMIC_ASSETS_LOADING_TEMPLATE.replace(
+            "<PATH_TO_CSS_ASSET>",
+            cssPath
+          ).replace("<PATH_TO_JS_ASSET>", jsPath);
+
+          // Remove the static link and script tags (they're now loaded dynamically)
+          updatedHtml = updatedHtml.replace(/\/cartridge.svg/g, "");
+          updatedHtml = html.replace(
+            /<script type="module" crossorigin src="[^"]+"><\/script>/g,
+            ""
+          );
+          updatedHtml = updatedHtml.replace(
+            /<link rel="stylesheet" crossorigin href="[^"]+">/g,
+            ""
+          );
+
+          // Insert the dynamic loading template after the <head> tag
+          updatedHtml = updatedHtml.replace(/<head>/, `<head>${updatedHtml}`);
+
+          return updatedHtml;
+        }
+
+        return html;
+      },
+    },
+  ];
+}

--- a/index.html
+++ b/index.html
@@ -1,13 +1,17 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/cartridge.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
-    <title>Cartridge Explorer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>Explorer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,12 +28,7 @@ function MainContent() {
 
 function App() {
   return (
-    <BrowserRouter
-      basename={
-        // See <vite.config.ts>.
-        import.meta.env.APP_BASE_PATH || "/"
-      }
-    >
+    <BrowserRouter basename={window.location.pathname}>
       <MainContent />
     </BrowserRouter>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,8 +27,15 @@ function MainContent() {
 }
 
 function App() {
+  // More robust basename determination
+  // Determine if we're at the root or in a subdirectory
+  const pathname = window.location.pathname;
+  const basename = pathname.endsWith("/")
+    ? pathname
+    : pathname.substring(0, pathname.lastIndexOf("/") + 1);
+
   return (
-    <BrowserRouter basename={window.location.pathname}>
+    <BrowserRouter basename={basename}>
       <MainContent />
     </BrowserRouter>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import dynamicLinksPlugin from "./dynamic-link";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), dynamicLinksPlugin()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
@@ -14,14 +15,5 @@ export default defineConfig({
       "@modules": path.resolve(__dirname, "./src/modules"),
       "@constants": path.resolve(__dirname, "./src/constants"),
     },
-  },
-  base: process.env.BASE_PATH,
-
-  // This allow us to set a custom base path for the application.
-  // Required when it is exposed in the `katana` under a non-root base path (ie `/explorer`).
-  //
-  // See <src/App.tsx>.
-  define: {
-    "import.meta.env.APP_BASE_PATH": JSON.stringify(process.env.BASE_PATH),
   },
 });


### PR DESCRIPTION
## Problem

When Explorer is exposed behind a reverse proxy (such is the case when it is hosted on `slot`), the application cannot determine the correct relative paths for web assets at build time.

### Current Behavior:

`katana` exposes Explorer at `localhost:5050/explorer` relative to the RPC server URL
During build time, the base path `/explorer` is appended to all asset paths:

```html
html<head>
  <script type="module" crossorigin src="/explorer/assets/index-cqfu6rb3.js"></script>
  <link rel="stylesheet" crossorigin href="/explorer/assets/index-bdhwn4o7.css">
</head>
```

When behind a reverse proxy, Explorer could be exposed at an arbitrary path, making it impossible to determine the correct base path at build time

## Solution

This PR implements dynamic path resolution for assets at runtime (when the HTML page loads). By using the current path as the base path, the application will correctly reference assets regardless of where the webpage is served from.

### Benefits:

- Works seamlessly with any proxy configuration
- No hardcoded paths that require configuration
- More robust deployment in various environments