### PR TITLE
chore: agentic standards

### DIFF
--- a/.agents/skills/create-a-plan/SKILL.md
+++ b/.agents/skills/create-a-plan/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: create-a-plan
+description: Conduct a focused technical planning interview to produce an implementable, parallelizable plan or spec with clear dependencies, risks, and open questions.
+---
+
+# Create a Plan Skill
+
+This skill runs a structured technical interview to turn a rough idea or an existing spec into a detailed, implementable plan. The output is organized for parallel execution: foundations first, then independent workstreams, then merge and integration.
+
+## Invocation
+
+The user will provide one of:
+- A path to a spec or plan file (for example: `SPEC.md`, `PLAN.md`, `RFC.md`)
+- A rough description of what they want to build
+- A feature request or problem statement
+
+Output is always written to `PLAN.md` in the repo root.
+
+## Process
+
+### Phase 0: Preflight
+
+1. If a file path is provided, read it first and note goals, non-goals, constraints, and gaps.
+2. Confirm you will produce `PLAN.md` as the output in the repo root. If `PLAN.md` already exists, update it rather than creating a new file.
+
+### Phase 1: Discovery
+
+Summarize what is known, then identify missing details. Focus on:
+- Goals and non-goals
+- Constraints (time, budget, platform, dependencies)
+- Success metrics and acceptance criteria
+
+### Phase 2: Deep Interview
+
+Use the `AskUserQuestion` (Claude) and/or `request_user_input` (Codex) tools in rounds. Ask 1-3 questions per round. Each round should go deeper and avoid repeating what is already known.
+
+CRITICAL RULES:
+1. Never ask obvious questions. If the codebase or spec already answers it, do not ask it again.
+2. Ask about edge cases and failure modes.
+3. Probe for hidden complexity (state transitions, migrations, concurrency).
+4. Challenge assumptions when they create risk or ambiguity.
+5. Identify parallelization boundaries and serial dependencies.
+6. If the user is unsure, propose a default and ask for confirmation.
+
+Question categories to cover as relevant:
+- Technical architecture and data flow
+- Data model and state management
+- API contracts and versioning
+- Caching and invalidation
+- Background jobs, retries, and idempotency
+- Error handling and recovery
+- Observability and debugging
+- Performance, scale, and SLAs
+- Security, privacy, and compliance
+- Integrations and external dependencies
+- UX flows, accessibility, and responsiveness
+- Rollout, migration, and rollback
+- Testing strategy and validation
+
+### Phase 3: Dependency Analysis
+
+Identify:
+1. Serial dependencies that must complete first
+2. Parallel workstreams that can run independently
+3. Merge points where work reconvenes
+
+### Phase 4: Plan Generation
+
+Write the final plan to `PLAN.md`. Ensure the plan includes concrete verification steps the agent can run end to end. If the user only wants a plan in chat, provide it inline and mention that it would be written to `PLAN.md`.
+
+## Output Format
+
+The generated plan MUST follow this structure:
+
+```markdown
+# [Feature Name] Implementation Plan
+
+## Overview
+[2-3 sentence summary of what this implements and why]
+
+## Goals
+- [Explicit goal 1]
+- [Explicit goal 2]
+
+## Non-Goals
+- [What this explicitly does NOT do]
+
+## Assumptions and Constraints
+- [Known constraints or assumptions]
+
+## Requirements
+
+### Functional
+- [Requirement]
+
+### Non-Functional
+- [Performance, reliability, security, compliance]
+
+## Technical Design
+
+### Data Model
+[Schema changes, new entities, relationships]
+
+### API Design
+[New endpoints, request/response shapes, versioning]
+
+### Architecture
+[System diagram in text or mermaid, component interactions]
+
+### UX Flow (if applicable)
+[Key screens, loading states, error recovery]
+
+---
+
+## Implementation Plan
+
+### Serial Dependencies (Must Complete First)
+
+These tasks create foundations that other work depends on. Complete in order.
+
+#### Phase 0: [Foundation Name]
+**Prerequisite for:** All subsequent phases
+
+| Task | Description | Output |
+|------|-------------|--------|
+| 0.1 | [Task description] | [Concrete deliverable] |
+| 0.2 | [Task description] | [Concrete deliverable] |
+
+---
+
+### Parallel Workstreams
+
+These workstreams can be executed independently after Phase 0.
+
+#### Workstream A: [Name]
+**Dependencies:** Phase 0
+**Can parallelize with:** Workstreams B, C
+
+| Task | Description | Output |
+|------|-------------|--------|
+| A.1 | [Task description] | [Concrete deliverable] |
+| A.2 | [Task description] | [Concrete deliverable] |
+
+#### Workstream B: [Name]
+**Dependencies:** Phase 0
+**Can parallelize with:** Workstreams A, C
+
+| Task | Description | Output |
+|------|-------------|--------|
+| B.1 | [Task description] | [Concrete deliverable] |
+
+---
+
+### Merge Phase
+
+After parallel workstreams complete, these tasks integrate the work.
+
+#### Phase N: Integration
+**Dependencies:** Workstreams A, B, C
+
+| Task | Description | Output |
+|------|-------------|--------|
+| N.1 | [Integration task] | [Concrete deliverable] |
+
+---
+
+## Testing and Validation
+
+- [Unit, integration, end-to-end coverage]
+- [Manual test plan if needed]
+
+## Rollout and Migration
+
+- [Feature flags, staged rollout, migration steps]
+- [Rollback plan]
+
+## Verification Checklist
+
+- [Exact commands or manual steps the agent can run to verify correctness]
+- [Expected outputs or success criteria]
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| [Risk description] | Low/Med/High | Low/Med/High | [Strategy] |
+
+## Open Questions
+
+- [ ] [Question that still needs resolution]
+
+## Decision Log
+
+| Decision | Rationale | Alternatives Considered |
+|----------|-----------|------------------------|
+| [Decision made] | [Why] | [What else was considered] |
+```
+
+## Interview Flow Example
+
+Round 1: High-Level Architecture
+- "The spec mentions a sync engine. Is this push-based (webhooks), pull-based (polling), or event-driven (queue)?"
+- "What is the expected data volume and throughput?"
+
+Round 2: Edge Cases
+- "If a batch fails mid-run, do we retry the whole batch or resume from a checkpoint?"
+- "What happens when source data is deleted but still referenced downstream?"
+
+Round 3: Parallelization
+- "Can we process different categories independently, or are there cross-category dependencies?"
+- "Is there a natural partition key that allows sharding?"
+
+Round 4: Operational
+- "What is the acceptable latency for sync or processing?"
+- "How will operators debug failures and what visibility do they need?"
+
+## Key Behaviors
+
+1. Persist until the plan is implementable and verifiable by the agent, but avoid user fatigue by batching questions.
+2. Challenge vague answers when they affect design decisions.
+3. Identify hidden work and operational overhead.
+4. Think about the merge and integration steps early.
+5. Summarize understanding and confirm before writing the final plan.
+
+## Completing the Interview
+
+After sufficient rounds of questions:
+1. Summarize your understanding back to the user
+2. Confirm the parallelization strategy
+3. Write the complete plan to the target file
+4. Ask if any sections need refinement

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: create-pr
+description: Create or update a PR from current branch to main, watch CI, and address feedback
+---
+The user likes the state of the code.
+
+There are $`git status --porcelain | wc -l | tr -d ' '` uncommitted changes.
+The current branch is $`git branch --show-current`.
+The target branch is origin/main.
+
+$`git rev-parse --abbrev-ref @{upstream} 2>/dev/null && echo "Upstream branch exists." || echo "There is no upstream branch yet."`
+
+**Existing PR:** $`gh pr view --json number,title,url --jq '"#\(.number): \(.title) - \(.url)"' 2>/dev/null || echo "None"`
+
+The user requested a PR.
+
+Follow these exact steps:
+
+## Phase 1: Review the code
+
+1. Review test coverage
+2. Check for silent failures
+3. Verify code comments are accurate
+4. Review any new types
+5. General code review
+
+## Phase 2: Create/Update PR
+
+6. Run `git diff` to review uncommitted changes
+7. Commit them. Follow any instructions the user gave you about writing commit messages.
+8. Push to origin.
+9. Use `git diff origin/main...` to review the full PR diff
+10. Check if a PR already exists for this branch:
+   - **If PR exists**:
+     - Draft/update the description in a temp file (e.g. `/tmp/pr-body.txt`).
+     - Update the PR body using the non-deprecated script:
+       - `./.agents/skills/create-pr/scripts/pr-body-update.sh --file /tmp/pr-body.txt`
+     - Re-fetch the body with `gh pr view --json body --jq .body` to confirm it changed.
+   - **If no PR exists**: Use `gh pr create --base main` to create a new PR. Keep the title under 80 characters and the description under five sentences.
+
+The PR description should summarize ALL commits in the PR, not just the latest changes.
+
+## Phase 3: Monitor CI and Address Issues
+
+Note: Keep commands CI-safe and avoid interactive `gh` prompts. Ensure `GH_TOKEN` or `GITHUB_TOKEN` is set in CI.
+
+11. Watch CI status and feedback using the polling script (instead of running `gh` in a loop):
+   - Run `./.agents/skills/create-pr/scripts/poll-pr.sh --triage-on-change --exit-when-green` (polls every 30s for 10 mins).
+   - If checks fail, use `gh pr checks` or `gh run list` to find the failing run id, then:
+     - Fetch the failed check logs using `gh run view <run-id> --log-failed`
+     - Analyze the failure and fix the issue
+     - Commit and push the fix
+     - Continue polling until all checks pass
+
+12. Check for merge conflicts:
+   - Run `git fetch origin main && git merge origin/main`
+   - If conflicts exist, resolve them sensibly
+   - Commit the merge resolution and push
+
+13. Use the polling script output to notice new reviews and comments (avoid direct polling via `gh`):
+   - If you need a full snapshot, run `./.agents/skills/create-pr/scripts/triage-pr.sh` once.
+   - If you need full context after the script reports a new item, fetch details once with `gh pr view --comments` or `gh api ...`.
+   - **Address feedback**:
+     - For bot reviews, read the review body and any inline comments carefully
+     - Address comments that are clearly actionable (bug fixes, typos, simple improvements)
+     - Skip comments that require design decisions or user input
+     - For addressed feedback, commit fixes with a message referencing the review/comment
+
+## Phase 4: Merge and Cleanup
+
+14. Once CI passes and the PR is approved, ask the user if they want to merge the PR.
+
+15. If the user confirms, merge the PR:
+    - Use `gh pr merge --squash --delete-branch` to squash-merge and delete the remote branch
+
+16. After successful merge, check if we're in a git worktree:
+    - Run: `[ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ]`
+    - **If in a worktree**: Use the ask user question tool (`request_user_input`) to ask if they want to clean up the worktree. If yes, run `wt remove --yes --force` to remove the worktree and local branch, then switch back to the main worktree.
+    - **If not in a worktree**: Just switch back to main with `git checkout main && git pull`
+
+## Completion
+
+Report the final PR status to the user, including:
+- PR URL
+- CI status (passed/merged)
+- Any unresolved review comments that need user attention
+- Cleanup status (worktree removed or branch switched)
+
+If any step fails in a way you cannot resolve, ask the user for help.

--- a/.agents/skills/create-pr/scripts/poll-pr.sh
+++ b/.agents/skills/create-pr/scripts/poll-pr.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+interval="${POLL_INTERVAL:-30}"
+minutes="${POLL_MINUTES:-10}"
+poll_once="${POLL_ONCE:-0}"
+pr=""
+repo=""
+exit_when_green=0
+triage_on_change=0
+
+usage() {
+  cat <<'USAGE'
+Usage: poll-pr.sh [--pr <number>] [--repo <owner/repo>] [--interval <seconds>] [--minutes <minutes>] [--exit-when-green] [--triage-on-change]
+
+Polls PR checks, review comments, and conversation comments every 30s for 10 minutes by default.
+Environment overrides: POLL_INTERVAL, POLL_MINUTES, POLL_ONCE=1.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      pr="$2"
+      shift 2
+      ;;
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --interval)
+      interval="$2"
+      shift 2
+      ;;
+    --minutes)
+      minutes="$2"
+      shift 2
+      ;;
+    --exit-when-green)
+      exit_when_green=1
+      shift 1
+      ;;
+    --triage-on-change)
+      triage_on_change=1
+      shift 1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$pr" ]]; then
+  pr="$(gh pr view --json number --jq .number 2>/dev/null || true)"
+fi
+
+if [[ -z "$pr" ]]; then
+  echo "Could not determine PR number. Use --pr <number>." >&2
+  exit 1
+fi
+
+if [[ -z "$repo" ]]; then
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+
+if [[ -z "$repo" ]]; then
+  echo "Could not determine repo. Use --repo owner/name." >&2
+  exit 1
+fi
+
+if ! [[ "$interval" =~ ^[0-9]+$ && "$minutes" =~ ^[0-9]+$ ]]; then
+  echo "interval and minutes must be integers." >&2
+  exit 1
+fi
+
+iterations=$(( (minutes * 60) / interval ))
+if (( iterations < 1 )); then
+  iterations=1
+fi
+if [[ "$poll_once" == "1" ]]; then
+  iterations=1
+fi
+
+echo "Polling PR #$pr in $repo every ${interval}s for ${minutes}m (${iterations} iterations)."
+
+last_issue_comment_id=""
+last_review_comment_id=""
+last_review_id=""
+last_failed_signature=""
+
+if ! gh auth status >/dev/null 2>&1; then
+  if [[ -z "${GITHUB_TOKEN:-}" && -z "${GH_TOKEN:-}" ]]; then
+    echo "Warning: gh auth not configured (set GH_TOKEN or GITHUB_TOKEN)."
+  fi
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+print_new() {
+  local kind="$1"
+  local time="$2"
+  local user="$3"
+  local url="$4"
+  local body="$5"
+
+  echo "New $kind by @$user at $time"
+  if [[ -n "$body" ]]; then
+    echo "  $body"
+  fi
+  if [[ -n "$url" ]]; then
+    echo "  $url"
+  fi
+}
+
+for i in $(seq 1 "$iterations"); do
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  echo "[$now] Poll $i/$iterations"
+  changed=0
+
+  checks_counts=$(gh pr checks "$pr" --repo "$repo" --json status,conclusion --jq '
+    [length,
+     (map(select(.status != "COMPLETED")) | length),
+     (map(select(.conclusion != null and .conclusion != "SUCCESS")) | length),
+     (map(select(.conclusion == "SUCCESS")) | length)
+    ] | @tsv
+  ' 2>/dev/null || true)
+  if [[ -n "$checks_counts" ]]; then
+    IFS=$'\t' read -r total pending failed success <<< "$checks_counts"
+    echo "Checks: total=$total pending=$pending failed=$failed success=$success"
+  else
+    echo "Checks: unavailable"
+  fi
+
+  failed_checks=$(gh pr checks "$pr" --repo "$repo" --json name,conclusion,detailsUrl --jq '
+    [.[] | select(.conclusion != null and .conclusion != "SUCCESS") |
+      "\(.name) (\(.conclusion))\t\(.detailsUrl // \"\")"
+    ] | .[]
+  ' 2>/dev/null || true)
+  failed_signature=$(gh pr checks "$pr" --repo "$repo" --json name,conclusion --jq '
+    [.[] | select(.conclusion != null and .conclusion != "SUCCESS") |
+      "\(.name):\(.conclusion)"
+    ] | sort | join("|")
+  ' 2>/dev/null || true)
+
+  if [[ -n "$failed_checks" ]]; then
+    echo "Failed checks:"
+    while IFS=$'\t' read -r name url; do
+      if [[ -n "$name" ]]; then
+        if [[ -n "$url" ]]; then
+          echo "  - $name $url"
+        else
+          echo "  - $name"
+        fi
+      fi
+    done <<< "$failed_checks"
+  fi
+  if [[ -n "$failed_signature" && "$failed_signature" != "$last_failed_signature" ]]; then
+    last_failed_signature="$failed_signature"
+    changed=1
+  fi
+
+  issue_line=$(gh api "repos/$repo/issues/$pr/comments?per_page=100" --jq '
+    if length == 0 then "" else
+      (max_by(.created_at)) | "\(.id)\t\(.created_at)\t\(.user.login)\t\(.html_url)\t\(.body | gsub("\\n"; " ") | gsub("\\t"; " ") | .[0:200])"
+    end
+  ' 2>/dev/null || true)
+  if [[ -n "$issue_line" ]]; then
+    IFS=$'\t' read -r issue_id issue_time issue_user issue_url issue_body <<< "$issue_line"
+    if [[ "$issue_id" != "$last_issue_comment_id" ]]; then
+      last_issue_comment_id="$issue_id"
+      print_new "conversation comment" "$issue_time" "$issue_user" "$issue_url" "$issue_body"
+      changed=1
+    fi
+  fi
+
+  review_comment_line=$(gh api "repos/$repo/pulls/$pr/comments?per_page=100" --jq '
+    if length == 0 then "" else
+      (max_by(.created_at)) | "\(.id)\t\(.created_at)\t\(.user.login)\t\(.html_url)\t\(.body | gsub("\\n"; " ") | gsub("\\t"; " ") | .[0:200])"
+    end
+  ' 2>/dev/null || true)
+  if [[ -n "$review_comment_line" ]]; then
+    IFS=$'\t' read -r rc_id rc_time rc_user rc_url rc_body <<< "$review_comment_line"
+    if [[ "$rc_id" != "$last_review_comment_id" ]]; then
+      last_review_comment_id="$rc_id"
+      print_new "inline review comment" "$rc_time" "$rc_user" "$rc_url" "$rc_body"
+      changed=1
+    fi
+  fi
+
+  review_line=$(gh api "repos/$repo/pulls/$pr/reviews?per_page=100" --jq '
+    [ .[] | select(.submitted_at != null) ] |
+    if length == 0 then "" else
+      (max_by(.submitted_at)) | "\(.id)\t\(.submitted_at)\t\(.user.login)\t\(.html_url)\t\(.state)\t\(.body | gsub("\\n"; " ") | gsub("\\t"; " ") | .[0:200])"
+    end
+  ' 2>/dev/null || true)
+  if [[ -n "$review_line" ]]; then
+    IFS=$'\t' read -r r_id r_time r_user r_url r_state r_body <<< "$review_line"
+    if [[ "$r_id" != "$last_review_id" ]]; then
+      last_review_id="$r_id"
+      print_new "review ($r_state)" "$r_time" "$r_user" "$r_url" "$r_body"
+      changed=1
+    fi
+  fi
+
+  if [[ "$triage_on_change" == "1" && "$changed" == "1" ]]; then
+    "$script_dir/triage-pr.sh" --pr "$pr" --repo "$repo" || true
+  fi
+
+  if [[ "$exit_when_green" == "1" && -n "${pending:-}" ]]; then
+    if (( pending == 0 && failed == 0 && total > 0 )); then
+      echo "Checks green; exiting early."
+      break
+    fi
+  fi
+
+  if (( i < iterations )); then
+    sleep "$interval"
+  fi
+done

--- a/.agents/skills/create-pr/scripts/pr-body-update.sh
+++ b/.agents/skills/create-pr/scripts/pr-body-update.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+body_file=""
+pr=""
+repo=""
+
+usage() {
+  cat <<'USAGE'
+Usage: pr-body-update.sh --file <path> [--pr <number>] [--repo <owner/repo>]
+
+Updates a PR body using the GraphQL updatePullRequest mutation and verifies the result.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --file)
+      body_file="$2"
+      shift 2
+      ;;
+    --pr)
+      pr="$2"
+      shift 2
+      ;;
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$body_file" ]]; then
+  echo "--file is required." >&2
+  exit 1
+fi
+
+if [[ ! -f "$body_file" ]]; then
+  echo "Body file not found: $body_file" >&2
+  exit 1
+fi
+
+if [[ ! -s "$body_file" ]]; then
+  echo "Body file is empty: $body_file" >&2
+  exit 1
+fi
+
+if [[ -z "$pr" ]]; then
+  pr="$(gh pr view --json number --jq .number 2>/dev/null || true)"
+fi
+
+if [[ -z "$pr" ]]; then
+  echo "Could not determine PR number. Use --pr <number>." >&2
+  exit 1
+fi
+
+if [[ -z "$repo" ]]; then
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+
+if [[ -z "$repo" ]]; then
+  echo "Could not determine repo. Use --repo owner/name." >&2
+  exit 1
+fi
+
+pr_id="$(gh pr view "$pr" --repo "$repo" --json id --jq .id 2>/dev/null || true)"
+if [[ -z "$pr_id" ]]; then
+  echo "Could not determine PR id for #$pr in $repo." >&2
+  exit 1
+fi
+
+gh api graphql \
+  -f query='mutation($id:ID!,$body:String!){updatePullRequest(input:{pullRequestId:$id, body:$body}){pullRequest{id}}}' \
+  -f id="$pr_id" \
+  -f body="$(cat "$body_file")" \
+  >/dev/null
+
+updated_body="$(gh pr view "$pr" --repo "$repo" --json body --jq .body 2>/dev/null || true)"
+if [[ -z "$updated_body" ]]; then
+  echo "Failed to fetch updated PR body for #$pr in $repo." >&2
+  exit 1
+fi
+
+if [[ "$updated_body" != "$(cat "$body_file")" ]]; then
+  echo "PR body mismatch after update." >&2
+  exit 1
+fi
+
+echo "Updated PR #$pr body in $repo."

--- a/.agents/skills/create-pr/scripts/triage-pr.sh
+++ b/.agents/skills/create-pr/scripts/triage-pr.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pr=""
+repo=""
+
+usage() {
+  cat <<'USAGE'
+Usage: triage-pr.sh [--pr <number>] [--repo <owner/repo>]
+
+Prints a single-shot summary of CI status, latest review, and latest comments.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      pr="$2"
+      shift 2
+      ;;
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$pr" ]]; then
+  pr="$(gh pr view --json number --jq .number 2>/dev/null || true)"
+fi
+
+if [[ -z "$pr" ]]; then
+  echo "Could not determine PR number. Use --pr <number>." >&2
+  exit 1
+fi
+
+if [[ -z "$repo" ]]; then
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+
+if [[ -z "$repo" ]]; then
+  echo "Could not determine repo. Use --repo owner/name." >&2
+  exit 1
+fi
+
+checks_counts=$(gh pr checks "$pr" --repo "$repo" --json status,conclusion --jq '
+  [length,
+   (map(select(.status != "COMPLETED")) | length),
+   (map(select(.conclusion != null and .conclusion != "SUCCESS")) | length),
+   (map(select(.conclusion == "SUCCESS")) | length)
+  ] | @tsv
+' 2>/dev/null || true)
+
+if [[ -n "$checks_counts" ]]; then
+  IFS=$'\t' read -r total pending failed success <<< "$checks_counts"
+  echo "CI: total=$total pending=$pending failed=$failed success=$success"
+else
+  echo "CI: unavailable"
+fi
+
+failed_checks=$(gh pr checks "$pr" --repo "$repo" --json name,conclusion,detailsUrl --jq '
+  [.[] | select(.conclusion != null and .conclusion != "SUCCESS") |
+    "\(.name)\t\(.conclusion)\t\(.detailsUrl // \"\")"
+  ] | .[]
+' 2>/dev/null || true)
+if [[ -n "$failed_checks" ]]; then
+  while IFS=$'\t' read -r name conclusion url; do
+    if [[ -n "$name" ]]; then
+      echo "FAIL: $name $conclusion $url"
+    fi
+  done <<< "$failed_checks"
+fi
+
+review_line=$(gh api "repos/$repo/pulls/$pr/reviews?per_page=100" --jq '
+  [ .[] | select(.submitted_at != null) ] |
+  if length == 0 then "" else
+    (max_by(.submitted_at)) | "\(.state)\t\(.user.login)\t\(.submitted_at)\t\(.html_url)"
+  end
+' 2>/dev/null || true)
+if [[ -n "$review_line" ]]; then
+  IFS=$'\t' read -r r_state r_user r_time r_url <<< "$review_line"
+  echo "REVIEW: $r_state $r_user $r_time $r_url"
+fi
+
+issue_line=$(gh api "repos/$repo/issues/$pr/comments?per_page=100" --jq '
+  if length == 0 then "" else
+    (max_by(.created_at)) | "\(.user.login)\t\(.created_at)\t\(.html_url)\t\(.body | gsub("\\n"; " ") | gsub("\\t"; " ") | .[0:200])"
+  end
+' 2>/dev/null || true)
+if [[ -n "$issue_line" ]]; then
+  IFS=$'\t' read -r c_user c_time c_url c_body <<< "$issue_line"
+  echo "COMMENT: conversation $c_user $c_time $c_url $c_body"
+fi
+
+review_comment_line=$(gh api "repos/$repo/pulls/$pr/comments?per_page=100" --jq '
+  if length == 0 then "" else
+    (max_by(.created_at)) | "\(.user.login)\t\(.created_at)\t\(.html_url)\t\(.body | gsub("\\n"; " ") | gsub("\\t"; " ") | .[0:200])"
+  end
+' 2>/dev/null || true)
+if [[ -n "$review_comment_line" ]]; then
+  IFS=$'\t' read -r rc_user rc_time rc_url rc_body <<< "$review_comment_line"
+  echo "COMMENT: inline $rc_user $rc_time $rc_url $rc_body"
+fi

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMRT)
+
+if [[ -z "$STAGED_FILES" ]]; then
+  exit 0
+fi
+
+# Node (.)
+NODE_FILES="$STAGED_FILES"
+if echo "$NODE_FILES" | grep -qE '\.(ts|tsx|js|jsx|json|css|scss|yml|yaml)$|^package\.json$|^pnpm-lock\.yaml$|^bun\.lockb?$|^biome\.json$|^tsconfig\..*\.json$'; then
+  echo 'Running Node checks (.)...'
+  bun run format:check
+  bun run lint
+  bun run test
+  bun run build
+
+  if ! git diff --quiet; then
+    echo 'Pre-commit modified files (likely formatting). Stage the changes and retry.'
+    git diff --name-only
+    exit 1
+  fi
+fi
+
+echo 'Pre-commit checks complete.'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,30 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+  id-token: write
+jobs:
+  claude-code-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/review"
+          # CLAUDE.md is a symlink to AGENTS.md in this repo; keep repo rules there.
+          claude_args: |
+            --max-turns 4

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,8 +8,8 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
-  id-token: write
 
+  id-token: write
 jobs:
   claude-code-review:
     runs-on: ubuntu-latest
@@ -20,36 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # The Claude Code Action validates that the workflow file exists on the default branch
-      # and is identical. This makes first-time installation (or updates) fail on the PR that
-      # introduces changes to this file. We preflight and skip gracefully in that case.
-      - name: Preflight (workflow integrity)
-        id: preflight
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          file_path=".github/workflows/claude-code-review.yml"
-          default_branch="${{ github.event.repository.default_branch }}"
-
-          git fetch --no-tags --depth=1 origin "${default_branch}"
-
-          if git cat-file -e "origin/${default_branch}:${file_path}" 2>/dev/null; then
-            if git diff --quiet "origin/${default_branch}" -- "${file_path}"; then
-              echo "should_run=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "reason=workflow_differs_from_default_branch" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "should_run=false" >> "$GITHUB_OUTPUT"
-          echo "reason=workflow_missing_on_default_branch" >> "$GITHUB_OUTPUT"
-
       - name: Claude Review
-        if: steps.preflight.outputs.should_run == 'true' && secrets.ANTHROPIC_API_KEY != ''
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -57,14 +28,3 @@ jobs:
           # CLAUDE.md is a symlink to AGENTS.md in this repo; keep repo rules there.
           claude_args: |
             --max-turns 4
-
-      - name: Claude Review (skipped)
-        if: steps.preflight.outputs.should_run != 'true'
-        run: |
-          echo "Skipping Claude review: ${{ steps.preflight.outputs.reason }}"
-          echo "This is expected when this workflow is first introduced or updated in a PR."
-
-      - name: Claude Review (skipped: missing secret)
-        if: steps.preflight.outputs.should_run == 'true' && secrets.ANTHROPIC_API_KEY == ''
-        run: |
-          echo "Skipping Claude review: missing ANTHROPIC_API_KEY secret."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,8 +8,8 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
-
   id-token: write
+
 jobs:
   claude-code-review:
     runs-on: ubuntu-latest
@@ -20,7 +20,36 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The Claude Code Action validates that the workflow file exists on the default branch
+      # and is identical. This makes first-time installation (or updates) fail on the PR that
+      # introduces changes to this file. We preflight and skip gracefully in that case.
+      - name: Preflight (workflow integrity)
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          file_path=".github/workflows/claude-code-review.yml"
+          default_branch="${{ github.event.repository.default_branch }}"
+
+          git fetch --no-tags --depth=1 origin "${default_branch}"
+
+          if git cat-file -e "origin/${default_branch}:${file_path}" 2>/dev/null; then
+            if git diff --quiet "origin/${default_branch}" -- "${file_path}"; then
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=workflow_differs_from_default_branch" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          echo "reason=workflow_missing_on_default_branch" >> "$GITHUB_OUTPUT"
+
       - name: Claude Review
+        if: steps.preflight.outputs.should_run == 'true' && secrets.ANTHROPIC_API_KEY != ''
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -28,3 +57,14 @@ jobs:
           # CLAUDE.md is a symlink to AGENTS.md in this repo; keep repo rules there.
           claude_args: |
             --max-turns 4
+
+      - name: Claude Review (skipped)
+        if: steps.preflight.outputs.should_run != 'true'
+        run: |
+          echo "Skipping Claude review: ${{ steps.preflight.outputs.reason }}"
+          echo "This is expected when this workflow is first introduced or updated in a PR."
+
+      - name: Claude Review (skipped: missing secret)
+        if: steps.preflight.outputs.should_run == 'true' && secrets.ANTHROPIC_API_KEY == ''
+        run: |
+          echo "Skipping Claude review: missing ANTHROPIC_API_KEY secret."

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+# Agent tooling (canonical in .agents/, symlinked into .claude/ and .cursor/)
+.agents/
+.claude/
+.cursor/
+AGENTS.md
+AGENT.md
+CLAUDE.md
+CLAUDE.legacy.md
+AGENT.legacy.md
+

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Describe top-level modules/directories and how they relate.
+
+## Build, Test, and Development Commands
+- `bun install`
+- `bun run format:check`
+- `bun run format`
+- `bun run lint`
+- `bun run build`
+- `bun run test`
+
+## Coding Style & Naming Conventions
+- Run the repo formatters/linters; do not hand-format.
+- Match existing naming and module layout.
+
+## Testing Guidelines
+- Add tests for behavior changes and regressions.
+- Prefer fast unit tests; add integration tests for cross-module behavior.
+
+## Commit & Pull Request Guidelines
+- Use concise, imperative commit subjects; link issues where applicable.
+- PRs must include: summary, rationale, and testing notes.
+
+## Agent Tooling
+
+- **Pre-commit hooks:** run `bin/setup-githooks` (configures `core.hooksPath` for this repo).
+
+- **Source of truth:** `.agents/`.
+- **Symlinks:** `CLAUDE.md` is a symlink to this file (`AGENTS.md`). Editor/agent configs should symlink skills from `.agents/skills`.
+- **Skills install/update:**
+
+```bash
+npm_config_cache=/tmp/npm-cache npx -y skills add https://github.com/cartridge-gg/agents   --skill create-pr create-a-plan   --agent claude-code cursor   -y
+```
+
+- **Configs:**
+  - `.agents/skills/` (canonical)
+  - `.claude/skills` -> `../.agents/skills`
+  - `.cursor/skills` -> `../.agents/skills`
+
+## Code Review Invariants
+
+- No secrets in code or logs.
+- Keep diffs small and focused; avoid drive-by refactors.
+- Add/adjust tests for behavior changes; keep CI green.
+- Prefer check-only commands in CI (`format:check`, `lint:check`) and keep local hooks aligned.
+- For Starknet/Cairo/Rust/crypto code: treat input validation, authZ, serialization, and signature/origin checks as **blocking** review items.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/bin/setup-githooks
+++ b/bin/setup-githooks
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+if [[ -d .husky ]]; then
+  git config core.hooksPath .husky
+  echo "Configured git hooksPath to .husky"
+else
+  git config core.hooksPath .githooks
+  echo "Configured git hooksPath to .githooks"
+fi


### PR DESCRIPTION
This PR standardizes agent/dev tooling:

- Add `AGENTS.md` as canonical agent instructions (`CLAUDE.md` symlinks to it).
- Add `.agents` as source of truth + `.claude`/`.cursor` compat symlinks.
- Install `create-pr` + `create-a-plan` skills from `cartridge-gg/agents`.
- Add `bin/setup-githooks` + `.githooks/pre-commit` (fast local mirror of CI checks).
- Add/refresh Claude Code Review workflow (includes `id-token: write` for OIDC).
